### PR TITLE
Fix compatibility with new databases

### DIFF
--- a/q2_micom/_build.py
+++ b/q2_micom/_build.py
@@ -3,7 +3,7 @@
 import biom
 import os
 import micom.workflows as mw
-from micom.taxonomy import build_from_qiime
+from micom.taxonomy import build_from_qiime, rank_prefixes
 import pandas as pd
 from q2_micom._formats_and_types import (
     JSONDirectory,
@@ -39,7 +39,10 @@ def build_spec(
     else:
         ranks = [rank]
 
-    tax = build_from_qiime(abundance, taxonomy, collapse_on=ranks)
+    no_rank_prefixes = rank_prefixes(model_files).isna().all()
+    tax = build_from_qiime(
+        abundance, taxonomy, collapse_on=ranks, trim_rank_prefix=no_rank_prefixes
+    )
     micom_taxonomy = pd.merge(model_files, tax, on=ranks)
     micom_taxonomy = micom_taxonomy[micom_taxonomy.relative > cutoff]
     del micom_taxonomy["file"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,17 +12,17 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 license = Apache License 2.0
 url = https://github.com/micom-dev/q2-micom
-classifiers = 
+classifiers =
 	Development Status :: 4 - Beta
 	Intended Audience :: Science/Research
 	Topic :: Scientific/Engineering :: Bio-Informatics
 	License :: OSI Approved :: Apache Software License
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
-keywords = 
+	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
+keywords =
 	microbiome
 	modeling
 	metabolism
@@ -32,25 +32,25 @@ keywords =
 zip_safe = False
 packages = find:
 python_requires = >=3.6
-install_requires = 
+install_requires =
 	cobra>=0.18.1
-	micom>=0.24.0
+	micom>=0.33.0
 	jinja2>=2.10.3
 	qiime2>=2021.2
 	rich>=6.0
 	pandas>=1.0
-tests_require = 
+tests_require =
 	coverage
 	pytest
 	pytest-cov
 	flake8
 
 [options.package_data]
-q2_micom = 
+q2_micom =
 	citations.bib
 
 [options.entry_points]
-qiime2.plugins = 
+qiime2.plugins =
 	q2-micom = q2_micom.plugin_setup:plugin
 
 [bumpversion:file:setup.py]
@@ -62,7 +62,7 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [tool:pytest]
-filterwarnings = 
+filterwarnings =
 	ignore::DeprecationWarning
 	ignore::FutureWarning
 
@@ -75,15 +75,15 @@ branch = True
 omit = q2_micom/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	def __repr__
 	if self\.debug
-	
+
 	raise AssertionError
 	raise NotImplementedError
-	
+
 	if 0:
 	if __name__ == .__main__.:
 ignore_errors = True


### PR DESCRIPTION
This fixes an issue with new model datbases that have rank prefixes in their taxonomy, for instance `g__Prevotella`. Those would fail to build since the table merger would always strip them. 