### PR TITLE
moshpit -> q2-moshpit

### DIFF
--- a/environment-files/q2-micom-qiime2-moshpit-2025.4.yml
+++ b/environment-files/q2-micom-qiime2-moshpit-2025.4.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
-  - moshpit
+  - qiime2-moshpit
   - cobra
   - optlang>=1.5.1
   - rich


### PR DESCRIPTION
@cdiener unfortunately, we recently changed the name of one of our environments for the coming release and I got the name wrong in the env file. Fortunately, I have a GitHub action to lint the environments. Unfortunately, it was not in place in time to catch the issue with this env. Fortunately, it is in place now!

Please do not merge this PR until qiime2/library-plugins#14 is passing ci. I will let you know here when that is.